### PR TITLE
Feature/read disk 1.0

### DIFF
--- a/boot-sector.asm
+++ b/boot-sector.asm
@@ -1,29 +1,55 @@
-; Boot sector program that prints the words
-; "Hello, World" and then loops forever.
+; Boot sector program that prints a message
+; to the screen before reading and printing
+; data from the disk and looping forever.
 
-; This directive explicitly states where in
-; memory the boot sector will be loaded so
-; that label references can be corrected.
 [org 0x7c00]
 
-mov bx, HELLO_MSG
+mov bx, BOOTING_MESSAGE
 call print_string
 
-; Hang on an infinite loop once the message
-; is printed to the screen.
+; Setup the stack.
+mov bp, 0x8000
+mov sp, bp
+
+; BIOS will read the sectors to the segment
+; es with an offset bx. Set the offset.
+mov bx, 0x9000
+
+; Select the number of sectors to read from
+; the disk.
+mov dh, 2
+
+call disk_load
+
+mov dx, [0x9000]
+call print_hex
+
+mov dx, [0x9000 + 512]
+call print_hex
+
 jmp $
 
 %include "print-string.asm"
+%include "print-hex.asm"
+%include "disk.asm"
 
-HELLO_MSG:
-    db 'Hello, World!', 0
+; Define a message that will be immediately
+; printed to the screen on boot.
+BOOTING_MESSAGE:
+    db "Booting, please wait...", 0
 
 ; The boot sector program must be 512 bytes
 ; so add enough zero bytes as padding while
 ; leaving enough room for the magic number.
-times  510-($-$$) db 0
+times 510-($-$$) db 0
 
 ; The last two bytes (one word) must be the
 ; magic number so that BIOS knows this is a
 ; boot sector.
 dw 0xaa55
+
+; Write two additional sectors of test data
+; to the disk to check if we can read bytes
+; from the disk. 
+times 256 dw 0xdada
+times 256 dw 0xface

--- a/disk.asm
+++ b/disk.asm
@@ -1,0 +1,41 @@
+; Set up all the registers before using the
+; BIOS read function. The registers purpose
+; are as follows:
+; ah - BIOS read sector function
+; al - Number of sectors to read
+; ch - Cylinder to read from
+; dh - Head to read from
+; cl - Sector to start reading from
+; Use interrupt 0x013 to read data from the
+; disk. If any errors occur print a message
+; to the screen.
+disk_load:
+    push dx
+
+    mov ah, 0x02
+    mov al, dh
+    mov ch, 0x00
+    mov dh, 0x00
+    mov cl, 0x02
+    
+    int 0x13
+
+    jc disk_error
+
+    pop dx
+    cmp dh, al
+    jne disk_error
+    ret
+
+; Print an error message to the screen when
+; the carry flag is set while attempting to
+; read the disk. Hang on an infinite loop.
+disk_error:
+    mov bx, DISK_ERROR_MSG
+    call print_string    
+    jmp $
+
+; Define the error message to  print to the
+; screen if the disk cannot be read.
+DISK_ERROR_MSG:
+    db "Disk read error!", 0

--- a/print-hex.asm
+++ b/print-hex.asm
@@ -1,0 +1,78 @@
+; Print the HEX value in the registry dx to
+; the screen.
+
+; Push all the registry values to the stack
+; so that they can be restored when the HEX
+; value is printed. Also, use cx to store a
+; counter to four which can be used to loop
+; through the HEX bytes.
+print_hex:
+    pusha
+    mov cx, 4
+
+; Loop over the counter in cx, decrementing
+; the value by one on each pass. Copy dx to
+; ax. Shift the value in dx four bits right
+; for the next iteration. Then mask all but
+; the last four bits in ax. The logical AND
+; operator along with the HEX value 0xf, or
+; 1111 in binary, can achieve this. HEX_OUT
+; is moved to bx before skipping the prefix
+; 0x and jumping to the position denoted by
+; cx, which the HEX value will be copied to
+; later. Compare ax to the HEX value 0xa to
+; check if it represents a number or letter
+; and do the following:
+; 1. If it's greater than 0ax, indicating a
+; letter, jump straight, to set_letter.
+; 2. If it's less than 0ax, which indicates
+; a number, then add 0x27 which in ASCII is
+; the difference between "9" and "a" before
+; jumping to set_letter.
+loop_characters:
+    dec cx
+
+    mov ax, dx
+    shr dx, 4
+    and ax, 0xf
+
+    mov bx, HEX_OUT
+    add bx, 2
+    add bx, cx
+
+    cmp ax, 0xa
+    jl set_letter
+    add al, 0x27
+
+    jl set_letter
+
+; To bring the value in al to the HEX value
+; of zero in the ASCII table add 0x30 to it
+; before moving the value to the byte in bx
+; denoted by the value of cx. Terminate the
+; loop if cx is equal to zero. Otherwise go
+; back and loop again. 
+set_letter:
+    add al, 0x30
+    mov byte[bx], al
+
+    cmp cx, 0
+    je end_print_hex
+
+    jmp loop_characters
+
+; Print the HEX value pointed to by HEX_OUT
+; to the screen before restoring all of the
+; registry values and returning to the line
+; where print_hex was called.
+end_print_hex:
+    mov bx, HEX_OUT
+    call print_string
+    popa
+    ret
+
+; Define a temporary variable which will be
+; used to store the HEX value to be printed
+; to the screen.
+HEX_OUT:
+    db "0x0000", 0

--- a/print-string.asm
+++ b/print-string.asm
@@ -21,7 +21,7 @@ print_string:
 print_next_letter:
     mov al, [bx]
     cmp al, 0
-    je end
+    je end_print_string
     int 0x10
 
     add bx, 1
@@ -32,7 +32,7 @@ print_next_letter:
 ; the original values of the registers, pop
 ; all their values off the stack. Return to
 ; the calling line.
-end:
+end_print_string:
     mov al, 0x0a
     int 0x10
 


### PR DESCRIPTION
### Description

Use a BIOS routine to read data from the disk. Also, added functionality to print HEX values to the screen for debugging purposes.

### Motivation

Eventually we will need to bootstrap the rest of our kernel from disk since no meaningful operating system can fit in the single 512 byte boot sector.

### How has this been tested?

Wrote two additional sectors of data to the disk. Compiled and ran the boot sector with QEMU. The first HEX value from both additional sectors were printed to the screen as expected.
